### PR TITLE
Configure package for CI and deployment to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+test/*
+Gruntfile.js
+.travis.yml
+.npmignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: node_js
+node_js: '0.10'
+deploy:
+  provider: npm
+  email: '{{npm email}}'
+  api_key:
+    secure: {{travis encrypt NPM api key}}
+  on:
+    tags: true
+    repo: katowulf/mockfirebase
+    all_branches: true

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "mockfirebase",
   "version": "0.2.4",
-  "description": "A Firebase stub/spy library for writing unit tests ",
+  "description": "A Firebase stub/spy library for writing unit tests",
   "main": "MockFirebase.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "grunt test"
   },
   "repository": {
     "type": "git",
@@ -25,12 +25,13 @@
     "sinon": "~1.9.0"
   },
   "devDependencies": {
-    "grunt": "~0.4.4",
-    "grunt-notify": "~0.2.20",
-    "grunt-contrib-watch": "~0.6.1",
-    "load-grunt-tasks": "~0.4.0",
-    "grunt-mocha-test": "~0.10.2",
     "chai": "~1.9.1",
+    "grunt": "~0.4.4",
+    "grunt-cli": "~0.1.13",
+    "grunt-contrib-watch": "~0.6.1",
+    "grunt-mocha-test": "~0.10.2",
+    "grunt-notify": "~0.2.20",
+    "load-grunt-tasks": "~0.4.0",
     "sinon-chai": "~2.5.0"
   }
 }


### PR DESCRIPTION
Just needs your npm email to be filled in, as well as your API key after running it through `travis encrypt`.
- Adds `npm test` as `grunt test`
- Configures Travis to run tests in CI
- Releases source/package + README to npm on tagged commits

Closes #3
