### PR TITLE
Avoid the "bad child path" exception after defining a child with leading slashes

### DIFF
--- a/browser/mockfirebase.js
+++ b/browser/mockfirebase.js
@@ -8781,7 +8781,7 @@ MockFirebase.prototype = {
 
   child: function(childPath) {
     if( !childPath ) { throw new Error('bad child path '+this.toString()); }
-    var parts = _.isArray(childPath)? childPath : childPath.split('/');
+    var parts = _.isArray(childPath)? childPath : _.compact(childPath.split('/'));
     var childKey = parts.shift();
     var child = this.children[childKey];
     if( !child ) {

--- a/src/MockFirebase.js
+++ b/src/MockFirebase.js
@@ -310,7 +310,7 @@ MockFirebase.prototype = {
 
   child: function(childPath) {
     if( !childPath ) { throw new Error('bad child path '+this.toString()); }
-    var parts = _.isArray(childPath)? childPath : childPath.split('/');
+    var parts = _.isArray(childPath)? childPath : _.compact(childPath.split('/'));
     var childKey = parts.shift();
     var child = this.children[childKey];
     if( !child ) {


### PR DESCRIPTION
It took me a while to debug this. 

I was using leading slashes as the firebase library supports them: firebase.child('/data/test'). Calling set on such instance lead to the "bad child path" exception.
