### PR TITLE
once should not throw away cancel function

### DIFF
--- a/src/MockFirebase.js
+++ b/src/MockFirebase.js
@@ -424,7 +424,7 @@ MockFirebase.prototype = {
         callback.call(context, snap);
       };
 
-      this.on(event, fn, context);
+      this.on(event, fn, cancel, context);
     }
   },
 


### PR DESCRIPTION
I just ran into an issue when the (undocumented) `forceCancel` does not call `cancel` on `once` listeners because the cancel function doesn't get passed through to `on`. This fixes that.

I'd add some tests, but there aren't any for cancelling that I can see.

```
var ref = new MockFirebase("https://foo.bar.com");
ref.once("value", function() {}, function() { console.log("cancelled once"); });
ref.on("value", function() {}, function() { console.log("cancelled on"); });
ref.forceCancel("error", "value");
```

Without the fix you only get "cancelled on", with it you get both.
