### PR TITLE
Add some missing mocked methods for snapshot

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -2,6 +2,9 @@
 
 var _ = require('lodash');
 
+var SERIAL_VALUE_KEY = '.value';
+var SERIAL_PRIORITY_KEY = '.priority';
+
 exports.makeSnap = function makeSnap (ref, data, pri) {
   data = _.cloneDeep(data);
   if (_.isObject(data) && _.isEmpty(data)) { data = null; }
@@ -15,6 +18,9 @@ exports.makeSnap = function makeSnap (ref, data, pri) {
     key: function () { return ref.key(); },
     getPriority: function () { return pri; },
     forEach: function(cb, scope) {
+      if (!_.isObject(data)) {
+        return;
+      }
       var self = this;
       _.each(data, function (v, k) {
         var res = cb.call(scope, self.child(k));
@@ -22,7 +28,45 @@ exports.makeSnap = function makeSnap (ref, data, pri) {
       });
     },
     child: function (key) {
-      return makeSnap(ref.child(key), _.isObject(data) && _.has(data, key)? data[key] : null, ref.child(key).priority);
+      return makeSnap(ref.child(key), this.hasChild(key)? data[key] : null, ref.child(key).priority);
+    },
+    hasChild: function (key) {
+      return _.isObject(data) && _.has(data, key);
+    },
+    hasChildren: function () {
+      return this.numChildren() > 0;
+    },
+    numChildren: function () {
+      if (_.isObject(data)) {
+        return _.size(data);
+      }
+      return 0;
+    },
+    exportVal: function () {
+      var isPrimitive = !_.isObject(data);
+      var priority = this.getPriority();
+      var hasPriority = _.isNumber(priority) || _.isString(priority);
+      var exportData;
+      if (hasPriority) {
+        exportData = {};
+        exportData[SERIAL_PRIORITY_KEY] = priority;
+      }
+      if (isPrimitive) {
+        if (_.isObject(exportData)) {
+          exportData[SERIAL_VALUE_KEY] = data;
+        } else {
+          exportData = data;
+        }
+      } else {
+        if (!_.isObject(exportData)) {
+          exportData = {};
+        }
+        _.reduce(data, function (memo, v, k) {
+          memo[k] = this.child(k).exportVal();
+          return memo;
+        }, exportData, this);
+      }
+      return exportData;
     }
   };
 };
@@ -38,11 +82,11 @@ exports.mergePaths = function mergePaths (base, add) {
 exports.cleanData = function cleanData(data) {
   var newData = _.clone(data);
   if(_.isObject(newData)) {
-    if(_.has(newData, '.value')) {
-      newData = _.clone(newData['.value']);
+    if(_.has(newData, SERIAL_VALUE_KEY)) {
+      newData = _.clone(newData[SERIAL_VALUE_KEY]);
     }
-    if(_.has(newData, '.priority')) {
-      delete newData['.priority'];
+    if(_.has(newData, SERIAL_PRIORITY_KEY)) {
+      delete newData[SERIAL_PRIORITY_KEY];
     }
 //      _.each(newData, function(v,k) {
 //        newData[k] = cleanData(v);

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -1,0 +1,205 @@
+'use strict';
+
+var sinon    = require('sinon');
+var _        = require('lodash');
+var expect   = require('chai').use(require('sinon-chai')).expect;
+var Firebase = require('../../').MockFirebase;
+var utils    = require('../../src/utils');
+
+describe('utils', function () {
+
+  var fb;
+  beforeEach(function () {
+    fb = new Firebase().child('data');
+  });
+
+  describe('#makeSnap', function () {
+
+    var snapshot;
+    describe('of string primitive with no priority', function () {
+
+      beforeEach(function () {
+        var data = 'foo';
+        var priority;
+        snapshot = utils.makeSnap(fb, data, priority);
+      });
+
+      describe('#val', function () {
+
+        it('should return data', function () {
+          expect(snapshot.val()).to.equal('foo');
+        });
+
+      });
+
+      describe('#ref', function () {
+
+        it('should return a firebase object', function () {
+          expect(snapshot.ref()).to.be.instanceOf(Firebase);
+        });
+
+      });
+
+      describe('#key', function () {
+
+        it('should return key of given firebase object', function () {
+          expect(snapshot.key()).to.equal('data');
+        });
+
+      });
+
+      describe('#getPriority', function () {
+
+        it('should return undefined', function () {
+          expect(snapshot.getPriority()).to.be.an('undefined');
+        });
+
+      });
+
+      describe('#forEach', function () {
+
+        it('should not invoke callback', function () {
+          var spy = sinon.spy();
+          snapshot.forEach(spy);
+          expect(spy).not.called;
+        });
+
+      });
+
+      describe('#hasChild', function () {
+
+        it('should be false', function () {
+          expect(snapshot.hasChild('bar')).to.be.false;
+        });
+
+      });
+
+      describe('#hasChildren', function () {
+
+        it('should be false', function () {
+          expect(snapshot.hasChildren()).to.be.false;
+        });
+
+      });
+
+      describe('#numChildren', function () {
+
+        it('should be zero', function () {
+          expect(snapshot.numChildren()).to.equal(0);
+        });
+
+      });
+
+      describe('#exportVal', function () {
+
+        it('should be just the original primitive', function () {
+          expect(snapshot.exportVal()).to.equal('foo');
+        });
+
+      });
+
+    });
+
+    describe('of numeric primitive with priority', function () {
+
+      beforeEach(function () {
+        var data = 5;
+        var priority = 2;
+        snapshot = utils.makeSnap(fb, data, priority);
+      });
+
+      describe('#getPriority', function () {
+
+        it('should return given priority', function () {
+          expect(snapshot.getPriority()).to.equal(2);
+        });
+
+      });
+
+      describe('#numChildren', function () {
+
+        it('should be zero', function () {
+          expect(snapshot.numChildren()).to.equal(0);
+        });
+
+      });
+
+      describe('#exportVal', function () {
+
+        it('should return object with value and priority', function () {
+          var exportedVal = snapshot.exportVal();
+          expect(exportedVal).to.have.property('.priority', 2);
+          expect(exportedVal).to.have.property('.value', 5);
+        });
+
+      });
+
+    });
+
+    describe('of object with priority', function () {
+
+      beforeEach(function () {
+        var data = {
+          'alpha': 'foo',
+          'bravo': 10,
+          'charlie': {
+            'bar': 'baz'
+          }
+        };
+        var priority = '3';
+        snapshot = utils.makeSnap(fb, data, priority);
+      });
+
+      describe('#getPriority', function () {
+
+        it('should return given priority', function () {
+          expect(snapshot.getPriority()).to.equal('3');
+        });
+
+      });
+
+      describe('#hasChild', function () {
+
+        it('should be true for valid key', function () {
+          expect(snapshot.hasChild('alpha')).to.be.true;
+        });
+
+        it('should be false for invalid key', function () {
+          expect(snapshot.hasChild('sierra')).to.be.false;
+        });
+
+      });
+
+      describe('#hasChildren', function () {
+
+        it('should be true', function () {
+          expect(snapshot.hasChildren()).to.be.true;
+        });
+
+      });
+
+      describe('#numChildren', function () {
+
+        it('should be equal to number of entries in data', function () {
+          expect(snapshot.numChildren()).to.equal(3);
+        });
+
+      });
+
+      describe('#exportVal', function () {
+
+        it('should return object with value and priority', function () {
+          var exportedVal = snapshot.exportVal();
+          expect(exportedVal).to.have.property('.priority', '3');
+          expect(exportedVal).to.have.property('alpha', 'foo');
+          expect(exportedVal).to.have.property('bravo', 10);
+          expect(exportedVal).to.have.deep.property('charlie.bar', 'baz');
+        });
+
+      });
+
+    });
+
+  });
+
+});


### PR DESCRIPTION
`MockFirebase` provided snapshot does not have all the methods referenced in the latest API documentation. This will add the missing methods.

Added:
- `hasChild`
- `hasChildren`
- `numChildren`
- `exportVal`

Also:
- refactored some existing code for correctness and duplication
- added some tests for `utils.makeSnapshot`

reference: https://www.firebase.com/docs/web/api/datasnapshot/
