### PR TITLE
fix: query.on overloading.

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -227,9 +227,7 @@ MockFirebase.prototype.once = function (event, callback, cancel, context) {
     context = cancel;
     cancel = _.noop;
   }
-  else if (arguments.length < 3) {
-    cancel = _.noop;
-  }
+  cancel = cancel || _.noop;
   var err = this._nextErr('once');
   if (err) {
     this._defer('once', _.toArray(arguments), function () {
@@ -261,9 +259,7 @@ MockFirebase.prototype.on = function (event, callback, cancel, context) {
     context = cancel;
     cancel = _.noop;
   }
-  else if (arguments.length < 3) {
-    cancel = _.noop;
-  }
+  cancel = cancel || _.noop;
 
   var err = this._nextErr('on');
   if (err) {

--- a/src/query.js
+++ b/src/query.js
@@ -48,9 +48,7 @@ MockQuery.prototype.on = function (event, callback, cancelCallback, context) {
     context = cancelCallback;
     cancelCallback = _.noop;
   }
-  else if (arguments.length < 3) {
-    cancelCallback = _.noop;
-  }
+  cancelCallback = cancelCallback || _.noop;
   var self = this;
   var isFirst = true;
   var lastSlice = this.slice();
@@ -105,7 +103,7 @@ MockQuery.prototype.on = function (event, callback, cancelCallback, context) {
     lastSlice = slice;
   }
   this._events.push([event, callback, context, handleRefEvent]);
-  this.ref().on(event, handleRefEvent, _.bind(cancelCallback || _.noop, context));
+  this.ref().on(event, handleRefEvent, _.bind(cancelCallback, context));
 };
 
 MockQuery.prototype.off = function (event, callback, context) {

--- a/src/query.js
+++ b/src/query.js
@@ -44,6 +44,13 @@ MockQuery.prototype.fakeEvent = function (event, snapshot) {
 };
 
 MockQuery.prototype.on = function (event, callback, cancelCallback, context) {
+  if (arguments.length === 3 && typeof cancel !== 'function') {
+    context = cancelCallback;
+    cancelCallback = _.noop;
+  }
+  else if (arguments.length < 3) {
+    cancelCallback = _.noop;
+  }
   var self = this;
   var isFirst = true;
   var lastSlice = this.slice();

--- a/test/unit/firebase.js
+++ b/test/unit/firebase.js
@@ -178,6 +178,21 @@ describe('MockFirebase', function () {
         .and.calledWith(err);
     });
 
+    it('cancel callbacks can be null', function(){
+      var context = {};
+      ref.on('value', spy, null, context);
+      ref.flush();
+      expect(spy).to.have.been.calledOn(context);
+      ref.forceCancel(new Error());
+
+      spy.reset();
+      ref.once('value', spy, null, context);
+      ref.flush();
+      expect(spy).to.have.been.calledOn(context);
+
+      ref.once('value', _.noop, null, context);
+      ref.forceCancel(new Error());
+    })
   });
 
   describe('#fakeEvent', function () {

--- a/test/unit/firebase.js
+++ b/test/unit/firebase.js
@@ -192,7 +192,7 @@ describe('MockFirebase', function () {
 
       ref.once('value', _.noop, null, context);
       ref.forceCancel(new Error());
-    })
+    });
   });
 
   describe('#fakeEvent', function () {

--- a/test/unit/query.js
+++ b/test/unit/query.js
@@ -119,6 +119,14 @@ describe('MockQuery', function () {
         ref.flush();
         expect(spy).callCount(1);
       });
+
+      it('can take the context as the 3rd argument', function () {
+        var spy = sinon.spy();
+        var context = {};
+        ref.limit(1).on('value', spy, context);
+        ref.flush();
+        expect(spy).to.have.been.calledOn(context);
+      });
     });
 
     describe('once', function() {


### PR DESCRIPTION
`query.on('eventName', callbackFunction, contextObject)` currently fails with `TypeError`.