### PR TITLE
deploy browser/* to npm. drop .npmignore for package.json/files. 

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,0 @@
-test/
-browser/
-gulpfile.js
-.travis.yml
-.npmignore
-helpers/
-coverage/

--- a/package.json
+++ b/package.json
@@ -19,6 +19,12 @@
   "bugs": {
     "url": "https://github.com/katowulf/mockfirebase/issues"
   },
+  "files": [
+    "*.md",
+    "src/",
+    "tutorials/",
+    "browser/"
+  ],
   "homepage": "https://github.com/katowulf/mockfirebase",
   "dependencies": {
     "MD5": "~1.2.1",


### PR DESCRIPTION
Increasingly I am using `npm` for all my dependencies (client side and otherwise). For those projects which I'm not building with browserify, I would like to see the browserified build deployed into npm.

Also, I personally have switched to using the "files" property of "package.json", instead of a separate `.npmignore` file. It always seems to end up more concise.