### PR TITLE
Removed unneeded globs from package.json/files

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,7 @@
     "url": "https://github.com/katowulf/mockfirebase/issues"
   },
   "files": [
-    "*.md",
     "src/",
-    "tutorials/",
     "browser/"
   ],
   "homepage": "https://github.com/katowulf/mockfirebase",


### PR DESCRIPTION
As noted [here](https://docs.npmjs.com/files/package.json#files), `README.md` and `LICENSE` are included automatically and I don't think we need to ship the other `.md` files in this repo for releases.

Also, as noted in [this discussion](https://github.com/katowulf/mockfirebase/pull/96#discussion_r41420122), shipping the `/tutorials` directory is just a waste of bandwidth.