### PR TITLE
Replace deprecated MD5 module with new md5 one

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,11 +25,11 @@
   ],
   "homepage": "https://github.com/katowulf/mockfirebase",
   "dependencies": {
-    "MD5": "~1.2.1",
     "browserify": "^6.3.2",
     "browserify-shim": "^3.8.0",
     "firebase-auto-ids": "~1.1.0",
-    "lodash": "~2.4.1"
+    "lodash": "~2.4.1",
+    "md5": "^2.0.0"
   },
   "devDependencies": {
     "chai": "~1.9.1",

--- a/src/login.js
+++ b/src/login.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var _   = require('lodash');
-var md5 = require('MD5');
+var md5 = require('md5');
 
 /*******************************************************************************
  * SIMPLE LOGIN


### PR DESCRIPTION
NPM 3 has been complaining about this one, API remains the same and tests pass, should be a harmless update.
